### PR TITLE
Missing libcck/clockdriver.def from source file list

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -74,6 +74,7 @@ ptpd_SOURCES =				\
 	dep/alarms.h			\
 	dep/alarms.c			\
 	libcck/clockdriver.h		\
+	libcck/clockdriver.def		\
 	libcck/clockdriver.c		\
 	libcck/clockdriver_interface.h	\
 	libcck/clockdriver_unix.h		\


### PR DESCRIPTION
`make dist` was missing a file. RPM build now works again.