### PR TITLE
Build fixes

### DIFF
--- a/m4/version.m4
+++ b/m4/version.m4
@@ -1,4 +1,4 @@
 m4_define([PTPD_URL],[https://github.com/wowczarek/ptpd/tree/wowczarek-2.3.2-ttransport])
 m4_define([RELEASE_DATE],[August, 2016])
-m4_define([VERSION_NUMBER],[2.3.2-libcck-ttransport-git])
+m4_define([VERSION_NUMBER],[2.3.2-linuxphc-git])
 

--- a/packagebuild/rpm-rh/rpmbuild.sh
+++ b/packagebuild/rpm-rh/rpmbuild.sh
@@ -6,7 +6,6 @@
 # build both versions: normal and slave-only
 SPEC=ptpd.spec
 rm *.rpm
-for slaveonly in 0 1; do
 
 PWD=`pwd`
 BUILDDIR=`mktemp -d /tmp/tmpbuild.XXXXXXXXX`
@@ -47,11 +46,11 @@ RPMFILE=$BUILDDIR/RPMS/`uname -m`/$ARCHIVE.`uname -m`.rpm
 SRPMFILE=$BUILDDIR/SRPMS/$ARCHIVE.src.rpm
 
 
-rpmbuild  --define "$GITTAG" --define "build_slaveonly $slaveonly" --define "_topdir $BUILDDIR" -ba $BUILDDIR/SPECS/$SPEC && { 
-    find $BUILDDIR -name "*.rpm" -exec mv {} $PWD \;
-}
+for slaveonly in 0 1; do
+    rpmbuild  --undefine "_unitdir" --define "$GITTAG" --define "build_slaveonly $slaveonly" --define "_topdir $BUILDDIR" -ba $BUILDDIR/SPECS/$SPEC && { 
+        find $BUILDDIR -name "*.rpm" -exec mv {} $PWD \;
+    }
+done
 
 rm -rf $BUILDDIR
 rm $TARBALL
-
-done

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -76,12 +76,13 @@ ptpd_SOURCES =				\
 	libcck/libcck.h			\
 	libcck/cck_types.h		\
 	libcck/cck_utils.h		\
+	libcck/log_handler.h		\
 	libcck/cck_utils.c		\
 	libcck/fd_set.h			\
 	libcck/fd_set.c			\
 	libcck/transport_address.h	\
 	libcck/transport_address.c	\
-	libcck/transport.h		\
+	libcck/ttransport.h		\
 	libcck/clockdriver.def		\
 	libcck/clockdriver.h		\
 	libcck/clockdriver.c		\


### PR DESCRIPTION
- Shortened VERSION_NUMBER to avoid filename character limit of GNU tar
- Don't do unnecessary work in rpmbuild slaveonly loop
- fixed missing and misnamed ptpd source files