### PR TITLE
call getSystemClockOffset from correct clock driver

### DIFF
--- a/src/libcck/clockdriver/clockdriver_linuxphc.c
+++ b/src/libcck/clockdriver/clockdriver_linuxphc.c
@@ -459,7 +459,7 @@ getOffsetFrom (ClockDriver *self, ClockDriver *from, CckTimestamp *delta)
 		if(!self->getSystemClockOffset(self, &deltaA)) {
 		    return false;
 		}
-		if(!self->getSystemClockOffset(from, &deltaB)) {
+		if(!from->getSystemClockOffset(from, &deltaB)) {
 		    return false;
 		}
 		tsOps.sub(delta, &deltaA, &deltaB);


### PR DESCRIPTION
Fix a bug where if synchronising from a standard Linux PHC clock to a Solar Flare it would cause a segfault.