### PR TITLE
Remove the packet match between DELAY_REQ and TS packet.

### DIFF
--- a/src/libcck/ttransport/linuxts_common.c
+++ b/src/libcck/ttransport/linuxts_common.c
@@ -562,17 +562,10 @@ getLinuxTxTimestamp(TTransport *transport, TTransportMessage *txMessage) {
 
 gameover:
 
-	if(tsMessage.hasTimestamp && transport->callbacks.matchData) {
-	    if(transport->callbacks.matchData(transport->owner, transport,
-						txMessage->data, txMessage->length,
-						tsMessage.data, tsMessage.length)) {
+	if(tsMessage.hasTimestamp) {
 		txMessage->timestamp = tsMessage.timestamp;
 		txMessage->hasTimestamp = true;
 		return;
-	    } else {
-		    CCK_DBG(THIS_COMPONENT"getTxTimestamp(%s) matchData: TX timestamp does not match transmitted messsage\n",
-					    transport->name);
-	    }
 	}
 	txMessage->hasTimestamp = false;
 	tsOps.clear(&txMessage->timestamp);


### PR DESCRIPTION
When run HW_TIMESTAMPING on raw eth socket; it fails to get
timestamp for DELAY_REQ, the reason is that it tries to match
msgs between DELAY_REQ and TS packet, but the size/msgType
never matches; the check should be removed.