### PR TITLE
Fixed some logging crashes

### DIFF
--- a/src/dep/sys.c
+++ b/src/dep/sys.c
@@ -393,8 +393,9 @@ logMessageWrapper(int priority, const char * format, va_list ap)
 	GlobalConfig *global = getGlobalConfig();
 	extern Boolean startupInProgress;
 
-	va_list ap1;
+	va_list ap1, ap2;
 	va_copy(ap1, ap);
+	va_copy(ap2, ap);
 
 #ifdef RUNTIME_DEBUG
 	if ((priority >= LOG_DEBUG) && (priority > global->debug_level)) {
@@ -441,7 +442,8 @@ logMessageWrapper(int priority, const char * format, va_list ap)
 			openlog(PTPD_PROGNAME, LOG_PID, LOG_DAEMON);
 			syslogOpened = TRUE;
 		}
-		vsyslog(priority, format, ap);
+		/* Use 'ap2' as 'ap' might have been consumed above. */
+		vsyslog(priority, format, ap2);
 		if (!startupInProgress) {
 			goto end;
 		}
@@ -456,6 +458,7 @@ std_err:
 	writeMessage(stderr, &global->eventLog.lastHash, priority, format, ap1);
 
 end:
+	va_end(ap2);
 	va_end(ap1);
 	va_end(ap);
 	return;

--- a/src/libcck/ttransport.c
+++ b/src/libcck/ttransport.c
@@ -291,7 +291,7 @@ detectTTransport(const int family, const char *path, const int caps, const int s
 	CCK_ERROR("detectTTransport(%s): Selected transport implementation %s not usable!\n",
 		path, getTTransportTypeName(specific));
     } else {
-	CCK_ERROR("detectTTransport(%s): no usable transport implementation found!\n");
+	CCK_ERROR("detectTTransport(%s): no usable transport implementation found!\n", path);
     }
 
     return TT_TYPE_NONE;

--- a/src/libcck/ttransport/socket_udpv4.c
+++ b/src/libcck/ttransport/socket_udpv4.c
@@ -108,7 +108,8 @@ tTransport_init(TTransport* self, const TTransportConfig *config, CckFdSet *fdSe
     copyCckTransportAddress(&self->hwAddress, &myData->intInfo.hwAddress);
 
     if(!self->hwAddress.populated) {
-	CCK_NOTICE(THIS_COMPONENT"tTransportInit(%s): No hardware address available, using protocol address for EUID\n");
+	CCK_NOTICE(THIS_COMPONENT"tTransportInit(%s): No hardware address available, using protocol address for EUID\n",
+		self->name);
     }
 
     /* if initialising with existing config, it's a restart */


### PR DESCRIPTION
Hi!

I have found a few issues with CCK log messages that are missing the arguments corresponding to the string formatting.
Another issue is in logMessageWrapper(), because in some situations, for example when logging in log file is enabled in the same time with syslog, vsyslog() function receives an already consumed variable argument list leading to problems.

Best regards,
Costin Popescu