### PR TITLE
Create and delete lock files so ptpd service is shut down safely

### DIFF
--- a/packagebuild/rpm-rh/ptpd.init
+++ b/packagebuild/rpm-rh/ptpd.init
@@ -16,6 +16,14 @@ RETVAL=0
 PATH=/sbin:/usr/local/bin:$PATH
 DAEMON_DESC="IEEE 1588 Precision Time Protocol (v2) daemon"
 
+if [ -d /var/lock/subsys ]; then
+  # RedHat/CentOS/etc who use subsys
+  LOCKFILE="/var/lock/subsys/ptpd"
+else
+  # The rest of them
+  LOCKFILE="/var/lock/ptpd"
+fi
+
 . /etc/init.d/functions
 
 if test -e /etc/sysconfig/ptpd ; then
@@ -47,6 +55,7 @@ start() {
 
 	if [ "$RETVAL" -eq "0" ] 
 	then 
+	touch ${LOCKFILE}
 		echo_success
 	else
 		echo_failure
@@ -116,6 +125,7 @@ stop() {
 		if [ "$RETVAL" -eq "0" ] 
 		then 
 			echo "Stopping $DAEMON_DESC...`echo_success`"
+			rm -f ${LOCKFILE}
 		else
 			echo "Stopping $DAEMON_DESC...`echo_failure`"
 		fi


### PR DESCRIPTION
Without the use of lock files in /var/lock/subsys/, the Red Hat RC scripts won't try and shut down a service on shutdown because they think it's not running.  Most of the time this is probably not a problem, but we've got some drivers here where if PTPd is still running and attempts to read a hardware timestamp from an interface when it's down, it causes a kernel panic. We can reproduce this consistently with hardware that uses the bnx2x driver, and running kernel 4.4.60.

These changes to the init script ensure PTPd is stopped correctly (early) during system shut down or reboot to avoid this problem.