### PR TITLE
Error in linuxphc_hw.conf

### DIFF
--- a/test/linuxphc_hw.conf
+++ b/test/linuxphc_hw.conf
@@ -70,7 +70,7 @@ ptpengine:log_announce_interval_max = 5
 ptpengine:log_sync_interval_max = 5
 ptpengine:log_delayreq_interval_max = 5
 ; P2P only
-ptpengine:log_peer_delayreq_interval = 5
+ptpengine:log_peer_delayreq_interval_max = 5
 
 ; initial delayReq interval is the interval a multicast slave
 ; uses until it receives the first response and learns the actual


### PR DESCRIPTION
I got the following error when using this config file:

```
ptpengine:log_peer_delayreq_interval value must be lower than ptpengine:log_peer_delayreq_interval_max
```

It appears that in the config file, `ptpengine:log_peer_delayreq_interval` is set twice, while `ptpengine:log_peer_delayreq_interval_max` is not set at all. It seemed like the second instantiation of `ptpengine:log_peer_delayreq_interval` should actually be the `max` version. This PR makes that change.